### PR TITLE
add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @hazelcast/documentation @pollett


### PR DESCRIPTION
This will set the docs team (and myself as a backstop) as codeowners, so we'll automatically get any PR reviews, and we'll set `main` to require one of our reviews to merge, sound ok @oliverhowell ?

Then creating a `staging` branch that can be for orchestrating next version changes